### PR TITLE
Fix handling of remote files when using carrierwave storage and s3.

### DIFF
--- a/lib/ratonvirus/storage/carrierwave.rb
+++ b/lib/ratonvirus/storage/carrierwave.rb
@@ -34,16 +34,12 @@ module Ratonvirus
       end
 
       def asset_remove(asset)
-        if asset.file.is_a?(CarrierWave::Storage::Fog::File)
-          @tempfile.close
-        else
-          path = asset.file.path
-          asset.remove!
+        path = asset.file.path
+        asset.remove!
 
-          # Remove the temp cache dir if it exists
-          dir = File.dirname(path)
-          FileUtils.remove_dir(dir) if File.directory?(dir)
-        end
+        # Remove the temp cache dir if it exists
+        dir = File.dirname(path)
+        FileUtils.remove_dir(dir) if File.directory?(dir)
       end
     end
   end

--- a/lib/ratonvirus/storage/carrierwave.rb
+++ b/lib/ratonvirus/storage/carrierwave.rb
@@ -23,7 +23,7 @@ module Ratonvirus
         if asset.file.is_a?(CarrierWave::Storage::Fog::File)
           # We can't use carrierwave_uploader.cache_stored_file! as this is
           # remote too when using fog/s3.
-          @tempfile ||= Tempfile.new(encoding: "ascii-8bit").tap do |f|
+          @tempfile = Tempfile.new(encoding: "ascii-8bit").tap do |f|
             f.write(asset.read)
             f.close
           end

--- a/lib/ratonvirus/storage/carrierwave.rb
+++ b/lib/ratonvirus/storage/carrierwave.rb
@@ -20,7 +20,18 @@ module Ratonvirus
         return if asset.nil?
         return if asset.file.nil?
 
-        yield asset.file.path
+        if asset.file.is_a?(CarrierWave::Storage::Fog::File)
+          # We can't use carrierwave_uploader.cache_stored_file! as this is
+          # remote too when using fog/s3.
+          @tempfile ||= Tempfile.new(encoding: "ascii-8bit").tap do |f|
+            f.write(asset.read)
+            f.close
+          end
+
+          yield @tempfile.path
+        else
+          yield asset.file.path
+        end
       end
 
       def asset_remove(asset)

--- a/lib/ratonvirus/storage/carrierwave.rb
+++ b/lib/ratonvirus/storage/carrierwave.rb
@@ -23,9 +23,8 @@ module Ratonvirus
         if asset.file.is_a?(CarrierWave::Storage::Fog::File)
           # We can't use carrierwave_uploader.cache_stored_file! as this is
           # remote too when using fog/s3.
-          @tempfile = Tempfile.new(encoding: "ascii-8bit").tap do |f|
+          @tempfile = Tempfile.new(encoding: "ascii-8bit") do |f|
             f.write(asset.read)
-            f.close
           end
 
           yield @tempfile.path
@@ -35,12 +34,16 @@ module Ratonvirus
       end
 
       def asset_remove(asset)
-        path = asset.file.path
-        asset.remove!
+        if asset.file.is_a?(CarrierWave::Storage::Fog::File)
+          @tempfile.close
+        else
+          path = asset.file.path
+          asset.remove!
 
-        # Remove the temp cache dir if it exists
-        dir = File.dirname(path)
-        FileUtils.remove_dir(dir) if File.directory?(dir)
+          # Remove the temp cache dir if it exists
+          dir = File.dirname(path)
+          FileUtils.remove_dir(dir) if File.directory?(dir)
+        end
       end
     end
   end

--- a/lib/ratonvirus/storage/carrierwave.rb
+++ b/lib/ratonvirus/storage/carrierwave.rb
@@ -23,8 +23,9 @@ module Ratonvirus
         if asset.file.is_a?(CarrierWave::Storage::Fog::File)
           # We can't use carrierwave_uploader.cache_stored_file! as this is
           # remote too when using fog/s3.
-          @tempfile = Tempfile.new(encoding: "ascii-8bit") do |f|
+          @tempfile = Tempfile.new(encoding: "ascii-8bit").tap do |f|
             f.write(asset.read)
+            f.close
           end
 
           yield @tempfile.path

--- a/spec/lib/ratonvirus/storage/carrierwave_spec.rb
+++ b/spec/lib/ratonvirus/storage/carrierwave_spec.rb
@@ -77,7 +77,7 @@ describe Ratonvirus::Storage::Carrierwave do
       it "yields with asset.file.path when a correct resource is given" do
         file = double
         path = double
-        expect(asset).to receive(:file).twice.and_return(file)
+        expect(asset).to receive(:file).exactly(3).times.and_return(file)
         expect(file).to receive(:path).and_return(path)
         expect { |b| subject.asset_path(asset, &b) }.to yield_with_args(
           path


### PR DESCRIPTION
When using carrierwave storage and fog/s3 scanning is not possible because the path that ratonvirus tries to open is not local. So you have to download the file from carrierwave/s3.

This pullrequest adds a check, if the attachment is a carrierwave fog attachment, it is first downloaded to a tempfile. The tempfile path it then used as asset path.

Please review the pr and accept if ok. Otherwise please point me to what have to be done to finish this fix.

Thanks in advance!