### PR TITLE
Fix checksum mismatch for StringIO

### DIFF
--- a/lib/ratonvirus/storage/support/io_handling.rb
+++ b/lib/ratonvirus/storage/support/io_handling.rb
@@ -23,8 +23,13 @@ module Ratonvirus
           begin
             tempfile.binmode
             if io.is_a?(StringIO)
+              orig_pos = io.pos
+              io.rewind
+
               # cannot specify src_offset for non-IO
               IO.copy_stream(io, tempfile)
+
+              io.pos = orig_pos
             else
               IO.copy_stream(io, tempfile, nil, 0)
             end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -10,6 +10,19 @@ module Ratonvirus
       def ratonvirus_file_fixture(filepath)
         "#{spec_path}/fixtures/files/#{filepath}"
       end
+
+      def activestorage_digest(io)
+        # This is how ActiveStorage would calculate the digest.
+        #
+        # See:
+        # https://github.com/rails/rails/blob/afd103d69abb7441da3d2ac5c737f8de3e678779/activestorage/lib/active_storage/service.rb#L161-L168
+        OpenSSL::Digest::MD5.new.tap do |checksum|
+          read_buffer = "".b
+          io.read(nil, read_buffer)
+          checksum << read_buffer
+          io.rewind
+        end.base64digest
+      end
     end
   end
 end

--- a/spec/integration/activestorage/antivirus_validator_spec.rb
+++ b/spec/integration/activestorage/antivirus_validator_spec.rb
@@ -49,6 +49,27 @@ describe AntivirusValidator do
         end
       end
 
+      # When a remote file is opened through OpenURI (i.e. URI.open(...)), the
+      # data is returned as StringIO. This ensures that the StringIO position
+      # does not change during scanning as that would break the digest
+      # calculation.
+      #
+      # See: https://github.com/mainio/ratonvirus/issues/36
+      context "and the file is provided as StringIO" do
+        let(:clean_string_io) { StringIO.new("clean content") }
+        let(:attachment) { { io: clean_string_io, filename: "clean_file.txt" } }
+
+        it "does not change the checksum of the file" do
+          expect(article).to be_valid
+
+          expect(clean_string_io.pos).to eq(0)
+
+          # In case the IO position is changed during the scanning, the digest
+          # would differ from the one calculated by ActiveStorage.
+          expect(article.activestorage_file.blob.checksum).to eq(activestorage_digest(clean_string_io))
+        end
+      end
+
       context "and the file is provided as blob reference" do
         let(:attachment) { clean_file_blob.signed_id }
 


### PR DESCRIPTION
Fix an issue when a StringIO is attached to ActiveStorage object, its IO position changes. This causes potentially checksum mismatches.

For an example, see #36.

Fix #36